### PR TITLE
Change link zatresi.si to klubi.si (redirect)

### DIFF
--- a/_posts/2015-02-28-zatresi.md
+++ b/_posts/2015-02-28-zatresi.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: "Zatresi"
-slug: zatresi
-source: http://www.zatresi.si/
+title: "Klubi Slovenije"
+slug: klubi
+source: http://www.klubi.si/
 ---
 
 <img src="/screenshots/zatresi.png">


### PR DESCRIPTION
zatresi.si has changed the url to klubi.si. While the 301 redirect is currently working, it might stop working in the future. Also, the project has been renamed to Klubi Slovenije.